### PR TITLE
feat: support card messages and store link metadata

### DIFF
--- a/mockServer.js
+++ b/mockServer.js
@@ -58,26 +58,80 @@ app.get('/api/messages', authMiddleware, (req, res) => {
 });
 
 app.post('/api/messages', authMiddleware, (req, res) => {
-  const { message } = req.body;
-  if (!message) {
+  const { type = 'text', content } = req.body;
+  if (!content) {
     return res.status(400).json({ error: 'Message required' });
   }
+
   const userMessages = req.user.messages;
   const userMessage = {
     id: userMessages.length + 1,
     role: 'user',
-    content: message,
-    timestamp: Date.now()
+    type,
+    content,
+    timestamp: Date.now(),
   };
   userMessages.push(userMessage);
-  const botMessage = {
-    id: userMessages.length + 1,
-    role: 'bot',
-    content: `Echo: ${message}`,
-    timestamp: Date.now()
-  };
+
+  let botMessage;
+  if (type === 'text') {
+    if (content === 'link') {
+      botMessage = {
+        id: userMessages.length + 1,
+        role: 'bot',
+        type: 'link',
+        content: {
+          title: '示例链接',
+          url: 'https://example.com',
+          description: 'Example link card',
+          thumbnail: 'https://via.placeholder.com/300',
+          ext: { note: 'sample' },
+        },
+        timestamp: Date.now(),
+      };
+    } else if (content === 'image') {
+      botMessage = {
+        id: userMessages.length + 1,
+        role: 'bot',
+        type: 'image',
+        content: {
+          url: 'https://via.placeholder.com/300',
+          description: '示例图片',
+        },
+        timestamp: Date.now(),
+      };
+    } else if (content === 'voice') {
+      botMessage = {
+        id: userMessages.length + 1,
+        role: 'bot',
+        type: 'audio',
+        content: {
+          url: 'https://www.w3schools.com/html/horse.mp3',
+          duration: 2,
+        },
+        timestamp: Date.now(),
+      };
+    } else {
+      botMessage = {
+        id: userMessages.length + 1,
+        role: 'bot',
+        type: 'text',
+        content: `Echo: ${content}`,
+        timestamp: Date.now(),
+      };
+    }
+  } else {
+    botMessage = {
+      id: userMessages.length + 1,
+      role: 'bot',
+      type,
+      content,
+      timestamp: Date.now(),
+    };
+  }
+
   userMessages.push(botMessage);
-  res.json({ reply: botMessage.content });
+  res.json({ message: botMessage });
 });
 
 const port = process.env.PORT || 3001;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,4 +1,4 @@
-import { autoResizeTextarea, toggleSendButton, appendUserMessage, appendBotMessage, showLoading, hideLoading, updateSendButtonPosition } from './ui.js';
+import { autoResizeTextarea, toggleSendButton, appendBotMessage, showLoading, hideLoading, updateSendButtonPosition, appendMessage } from './ui.js';
 import { register, login, fetchMessages, sendMessage } from './chatService.js';
 
 const messageInput = document.querySelector('.message-input');
@@ -39,11 +39,7 @@ async function loadMessages(page) {
   state.total = result.data.total || 0;
   list.forEach(msg => {
     state.messages.push(msg);
-    if (msg.role === 'user') {
-      appendUserMessage(messagesContainer, msg.content);
-    } else {
-      appendBotMessage(messagesContainer, msg.content);
-    }
+    appendMessage(messagesContainer, msg);
   });
   if (state.messages.length >= state.total) {
     loadMoreBtn.style.display = 'none';
@@ -62,8 +58,9 @@ async function handleSend() {
   const text = messageInput.value.trim();
   if (!text) return;
 
-  state.messages.push({ role: 'user', content: text });
-  appendUserMessage(messagesContainer, text);
+  const userMsg = { role: 'user', type: 'text', content: text };
+  state.messages.push(userMsg);
+  appendMessage(messagesContainer, userMsg);
   resetInput();
 
   state.loading = true;
@@ -76,8 +73,8 @@ async function handleSend() {
   if (result.error) {
     appendBotMessage(messagesContainer, `错误：${result.error}`);
   } else {
-    state.messages.push({ role: 'bot', content: result.data });
-    appendBotMessage(messagesContainer, result.data);
+    state.messages.push(result.data);
+    appendMessage(messagesContainer, result.data);
   }
 }
 

--- a/src/js/chatService.js
+++ b/src/js/chatService.js
@@ -58,9 +58,10 @@ export async function fetchMessages(page = 1, limit = 20, timeout) {
 }
 
 export async function sendMessage(message, timeout = 10000) {
-  const result = await request('/messages', { method: 'POST', body: { message }, timeout });
-  if (result.data && typeof result.data.reply === 'string') {
-    return { data: result.data.reply };
+  const body = typeof message === 'string' ? { type: 'text', content: message } : message;
+  const result = await request('/messages', { method: 'POST', body, timeout });
+  if (result.data && result.data.message) {
+    return { data: result.data.message };
   }
   return result;
 }

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -76,6 +76,117 @@ export function appendBotMessage(container, text) {
   container.scrollTop = container.scrollHeight;
 }
 
+function createLinkCard(data) {
+  const card = document.createElement('a');
+  card.className = 'message-card';
+  card.href = data.url;
+  card.target = '_blank';
+  if (data.ext) {
+    card.dataset.ext = JSON.stringify(data.ext);
+  }
+
+  if (data.thumbnail) {
+    const img = document.createElement('img');
+    img.src = data.thumbnail;
+    img.alt = data.title || '';
+    card.appendChild(img);
+  }
+
+  const content = document.createElement('div');
+  content.className = 'card-content';
+
+  if (data.title) {
+    const title = document.createElement('div');
+    title.className = 'card-title';
+    title.textContent = data.title;
+    content.appendChild(title);
+  }
+  if (data.description) {
+    const desc = document.createElement('div');
+    desc.className = 'card-description';
+    desc.textContent = data.description;
+    content.appendChild(desc);
+  }
+  const link = document.createElement('div');
+  link.className = 'card-link';
+  link.textContent = data.url;
+  content.appendChild(link);
+
+  card.appendChild(content);
+  return card;
+}
+
+function createImageCard(data) {
+  const card = document.createElement('div');
+  card.className = 'message-card';
+  const img = document.createElement('img');
+  img.src = data.url;
+  img.alt = data.alt || '';
+  card.appendChild(img);
+  if (data.title || data.description) {
+    const content = document.createElement('div');
+    content.className = 'card-content';
+    if (data.title) {
+      const title = document.createElement('div');
+      title.className = 'card-title';
+      title.textContent = data.title;
+      content.appendChild(title);
+    }
+    if (data.description) {
+      const desc = document.createElement('div');
+      desc.className = 'card-description';
+      desc.textContent = data.description;
+      content.appendChild(desc);
+    }
+    card.appendChild(content);
+  }
+  return card;
+}
+
+function createAudioCard(data) {
+  const card = document.createElement('div');
+  card.className = 'audio-message as-received-card';
+  const audio = document.createElement('audio');
+  audio.controls = true;
+  audio.src = data.url;
+  card.appendChild(audio);
+  if (data.duration) {
+    const duration = document.createElement('div');
+    duration.className = 'audio-duration';
+    duration.textContent = `${data.duration}s`;
+    card.appendChild(duration);
+  }
+  return card;
+}
+
+export function appendMessage(container, msg) {
+  if (!msg) return;
+  if (msg.type === 'text') {
+    if (msg.role === 'user') {
+      appendUserMessage(container, msg.content);
+    } else {
+      appendBotMessage(container, msg.content);
+    }
+    return;
+  }
+
+  const messageGroup = document.createElement('div');
+  messageGroup.className = `message-group ${msg.role === 'user' ? 'sent' : 'received'}`;
+  let element;
+  if (msg.type === 'link') {
+    element = createLinkCard(msg.content);
+  } else if (msg.type === 'image') {
+    element = createImageCard(msg.content);
+  } else if (msg.type === 'audio') {
+    element = createAudioCard(msg.content);
+  }
+  if (element) {
+    messageGroup.appendChild(element);
+    container.appendChild(messageGroup);
+    container.scrollTop = container.scrollHeight;
+  }
+}
+
 let loadingGroup = null;
 export function showLoading(container) {
   if (loadingGroup) return;


### PR DESCRIPTION
## Summary
- Allow backend `/api/messages` to accept `type` and `content` to return link, image, or audio cards
- Preserve link card extension data for future logic by storing JSON in `data-ext`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae5db59a0832d986a20ce04a2d557