### PR TITLE
style: refine media cards

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -77,16 +77,15 @@ export function appendBotMessage(container, text) {
 }
 
 function createLinkCard(data) {
-  const card = document.createElement('a');
+  const card = document.createElement('div');
   card.className = 'message-card';
-  card.href = data.url;
-  card.target = '_blank';
   if (data.ext) {
     card.dataset.ext = JSON.stringify(data.ext);
   }
 
   if (data.thumbnail) {
     const img = document.createElement('img');
+    img.className = 'card-image';
     img.src = data.thumbnail;
     img.alt = data.title || '';
     card.appendChild(img);
@@ -107,9 +106,11 @@ function createLinkCard(data) {
     desc.textContent = data.description;
     content.appendChild(desc);
   }
-  const link = document.createElement('div');
+  const link = document.createElement('a');
   link.className = 'card-link';
-  link.textContent = data.url;
+  link.href = data.url;
+  link.target = '_blank';
+  link.textContent = data.linkText || '查看详情 →';
   content.appendChild(link);
 
   card.appendChild(content);
@@ -118,44 +119,64 @@ function createLinkCard(data) {
 
 function createImageCard(data) {
   const card = document.createElement('div');
-  card.className = 'message-card';
+  card.className = 'message-card image-card';
   const img = document.createElement('img');
+  img.className = 'card-image';
   img.src = data.url;
   img.alt = data.alt || '';
   card.appendChild(img);
-  if (data.title || data.description) {
-    const content = document.createElement('div');
-    content.className = 'card-content';
-    if (data.title) {
-      const title = document.createElement('div');
-      title.className = 'card-title';
-      title.textContent = data.title;
-      content.appendChild(title);
-    }
-    if (data.description) {
-      const desc = document.createElement('div');
-      desc.className = 'card-description';
-      desc.textContent = data.description;
-      content.appendChild(desc);
-    }
-    card.appendChild(content);
-  }
   return card;
 }
 
 function createAudioCard(data) {
   const card = document.createElement('div');
   card.className = 'audio-message as-received-card';
-  const audio = document.createElement('audio');
-  audio.controls = true;
-  audio.src = data.url;
-  card.appendChild(audio);
+
+  const playBtn = document.createElement('button');
+  playBtn.className = 'play-btn';
+  playBtn.textContent = '▶';
+  card.appendChild(playBtn);
+
+  const progress = document.createElement('div');
+  progress.className = 'audio-progress';
+  const bar = document.createElement('div');
+  bar.className = 'progress-bar';
+  progress.appendChild(bar);
+  card.appendChild(progress);
+
   if (data.duration) {
     const duration = document.createElement('div');
     duration.className = 'audio-duration';
     duration.textContent = `${data.duration}s`;
     card.appendChild(duration);
   }
+
+  const audio = document.createElement('audio');
+  audio.src = data.url;
+  card.appendChild(audio);
+
+  playBtn.addEventListener('click', () => {
+    if (audio.paused) {
+      audio.play();
+      playBtn.textContent = '⏸';
+    } else {
+      audio.pause();
+      playBtn.textContent = '▶';
+    }
+  });
+
+  audio.addEventListener('timeupdate', () => {
+    if (audio.duration) {
+      const percent = (audio.currentTime / audio.duration) * 100;
+      bar.style.width = `${percent}%`;
+    }
+  });
+
+  audio.addEventListener('ended', () => {
+    playBtn.textContent = '▶';
+    bar.style.width = '0%';
+  });
+
   return card;
 }
 

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -86,6 +86,9 @@
         .card-description { font-size: 13px; font-weight: 400; color: #666; line-height: 1.4; margin-bottom: 12px; }
         .card-link { font-size: 12px; font-weight: 500; color: #3b82f6; text-decoration: none; }
 
+        .image-card { display: inline-block; max-width: 400px; }
+        .image-card img { width: auto; height: auto; max-width: 100%; max-height: 400px; }
+
         .document-message.as-received-card {
             display: flex; align-items: center; gap: 12px; padding: 14px 16px;
         }
@@ -94,13 +97,14 @@
         .doc-name { font-size: 14px; font-weight: 600; color: #1a1a1a; margin-bottom: 2px; }
         .doc-size { font-size: 12px; font-weight: 400; color: #666; }
 
-        .audio-message.as-received-card {
-            display: flex; align-items: center; gap: 12px; min-width: 260px;
-        }
-        .play-btn { width: 32px; height: 32px; border: none; border-radius: 50%; background: #3b82f6; color: white; display: flex; align-items: center; justify-content: center; cursor: pointer; font-size: 14px; }
-        .audio-progress { flex: 1; height: 4px; background: rgba(0,0,0,0.1); border-radius: 2px; overflow: hidden; }
-        .progress-bar { width: 30%; height: 100%; background: #3b82f6; }
-        .audio-duration { font-size: 12px; font-weight: 500; color: #3b82f6; }
+.audio-message.as-received-card {
+    display: flex; align-items: center; gap: 12px; min-width: 260px;
+}
+.play-btn { width: 32px; height: 32px; border: none; border-radius: 50%; background: #3b82f6; color: white; display: flex; align-items: center; justify-content: center; cursor: pointer; font-size: 14px; }
+.audio-progress { flex: 1; height: 4px; background: rgba(0,0,0,0.1); border-radius: 2px; overflow: hidden; }
+.progress-bar { width: 30%; height: 100%; background: #3b82f6; }
+.audio-duration { font-size: 12px; font-weight: 500; color: #3b82f6; }
+.audio-message audio { display: none; }
 
         .emoji-message { font-size: 48px; text-align: center; padding: 20px; background: transparent; box-shadow: none; }
 
@@ -195,6 +199,7 @@
         @media (max-width: 768px) {
             .message { max-width: 85%; }
             .message-card { max-width: 90%; }
+            .image-card { max-width: min(90%, 400px); }
         }
         @keyframes messageSlide { from { opacity: 0; transform: translateY(10px);} to { opacity: 1; transform: translateY(0);} }
 


### PR DESCRIPTION
## Summary
- restructure link cards to wrap content in a div and expose a dedicated anchor for details
- size image cards by their natural dimensions while capping width and height
- keep custom-styled audio cards with play button and progress bar

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b1faff378832da17cc0d2e6ee115c